### PR TITLE
speeding up POST

### DIFF
--- a/src/Arango/Arango.Client/Protocol/Operations/DocumentOperation.cs
+++ b/src/Arango/Arango.Client/Protocol/Operations/DocumentOperation.cs
@@ -59,7 +59,14 @@ namespace Arango.Client.Protocol
         {
             var request = new Request(RequestType.Document, HttpMethod.Post);
             request.RelativeUri = _apiUri;
-            request.Body = document.Except("_id", "_key", "_rev").Serialize();
+	    request.Body = document.Serialize();
+            if (
+                request.Body.Contains("_id")
+                || request.Body.Contains("_key")
+                || request.Body.Contains("_rev")
+            ) {
+                request.Body = document.Except("_id", "_key", "_rev").Serialize();
+	    }
             
             // set collection name where the document will be created
             request.QueryString.Add("collection", collection);


### PR DESCRIPTION
Hi!

I noticed, that creating documents is very slow, because of cloning the document every time to prevent committing "_key" etc.
It took about 16 secs for 1000 docs
I changed it a bit, so now it takes about 0.5 secs for 1000 documents (whithout "_id" etc)

br
