### PR TITLE
Add support for sharded collections

### DIFF
--- a/src/Arango/Arango.Client/API/Admin/ArangoServerOperation.cs
+++ b/src/Arango/Arango.Client/API/Admin/ArangoServerOperation.cs
@@ -1,0 +1,29 @@
+﻿using Arango.Client.Protocol;
+
+namespace Arango.Client
+{
+    /// <summary> 
+    /// Expose Arango server functionality.
+    /// </summary>
+    public class ArangoServerOperation
+    {
+        private ServerOperation _serverOperation;
+        
+        internal ArangoServerOperation(ServerOperation serverOperation)
+        {
+            _serverOperation = serverOperation;
+        }
+        
+        #region Role
+        
+        /// <summary> 
+        /// Retrieves the server role
+        /// </summary>
+        public ArangoServerRole Role()
+        {
+        	return _serverOperation.Role();
+        }
+                
+        #endregion
+    }
+}

--- a/src/Arango/Arango.Client/API/Admin/ArangoServerRole.cs
+++ b/src/Arango/Arango.Client/API/Admin/ArangoServerRole.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+namespace Arango.Client
+{
+    /// <summary>
+    /// Stores server role.
+    /// </summary>
+    public class ArangoServerRole
+    {
+    	public enum RoleType
+    	{
+    		COORDINATOR,
+    		DBSERVER,
+    		UNKNOWN
+    	}
+    	
+        /// <summary>
+        /// Server role
+        /// </summary>        
+        public RoleType Role { get; set; }            	
+
+        /// <summary>
+        /// Server role constructor
+        /// </summary>
+        public ArangoServerRole(string role)
+        {
+        	if (role.Equals("COORDINATOR"))
+        	{
+        		Role = RoleType.COORDINATOR;
+        	}
+        	else if (role.Equals("DBSERVER"))
+        	{
+        		Role = RoleType.DBSERVER;
+        	}
+        	else 
+        	{
+        		Role = RoleType.UNKNOWN;
+        	}
+        }
+        
+        /// <summary>
+        /// Server role constructor
+        /// </summary>
+        public ArangoServerRole(RoleType role)
+        {
+        	Role = role;
+        }
+        
+        public bool IsCoordinator()
+        {
+        	return Role == RoleType.COORDINATOR;
+        }
+
+        public bool IsCluster()
+        {
+        	return (Role == RoleType.COORDINATOR || Role == RoleType.DBSERVER);
+        }
+        
+    }
+}

--- a/src/Arango/Arango.Client/API/Admin/ArangoVersion.cs
+++ b/src/Arango/Arango.Client/API/Admin/ArangoVersion.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace Arango.Client
+{
+    /// <summary>
+    /// Stores server version data.
+    /// </summary>
+    public class ArangoVersion
+    {
+        /// <summary>
+        /// Major version part.
+        /// </summary>
+        public int Major { get; set; }
+        
+        /// <summary>
+        /// Minor version part.
+        /// </summary>
+        public int Minor { get; set; }
+        
+        /// <summary>
+        /// Patch-level version part.
+        /// </summary>
+        public int PatchLevel { get; set; }
+
+        /// <summary>
+        /// Full version string
+        /// </summary>        
+        public string Version { get; set; }
+        
+        /// <summary>
+        /// Version constructor
+        /// </summary>
+        public ArangoVersion(string version)
+        {
+        	Version = version;
+        	
+        	Regex re = new Regex(@"^(\d+)\.(\d+)\.(\d+).*$");
+            Match match = re.Match(version);
+            
+            if (re.IsMatch(version))
+            {
+            	Major = Convert.ToInt32(match.Groups[1].ToString());
+            	Minor = Convert.ToInt32(match.Groups[2].ToString());
+            	PatchLevel = Convert.ToInt32(match.Groups[3].ToString());
+            }
+        }
+        
+        public int toInt() 
+        {
+        	return PatchLevel + 100 * Minor + 10000 * Major;
+        }
+        
+    }
+}

--- a/src/Arango/Arango.Client/API/Admin/ArangoVersionOperation.cs
+++ b/src/Arango/Arango.Client/API/Admin/ArangoVersionOperation.cs
@@ -1,0 +1,29 @@
+﻿using Arango.Client.Protocol;
+
+namespace Arango.Client
+{
+    /// <summary> 
+    /// Expose Arango version functionality.
+    /// </summary>
+    public class ArangoVersionOperation
+    {
+        private VersionOperation _versionOperation;
+        
+        internal ArangoVersionOperation(VersionOperation versionOperation)
+        {
+            _versionOperation = versionOperation;
+        }
+        
+        #region Get
+        
+        /// <summary> 
+        /// Retrieves the version of the server
+        /// </summary>
+        public ArangoVersion Get()
+        {
+        	return _versionOperation.Get();
+        }
+                
+        #endregion
+    }
+}

--- a/src/Arango/Arango.Client/API/ArangoClient.cs
+++ b/src/Arango/Arango.Client/API/ArangoClient.cs
@@ -16,7 +16,7 @@ namespace Arango.Client
         /// <summary>
         /// Version of the driver.
         /// </summary>
-        public const string DriverVersion = "0.8.0";
+        public const string DriverVersion = "0.8.1";
         
         /// <summary>
         /// Driver global settings object.

--- a/src/Arango/Arango.Client/API/ArangoDatabase.cs
+++ b/src/Arango/Arango.Client/API/ArangoDatabase.cs
@@ -65,6 +65,28 @@ namespace Arango.Client
             }
         }
 
+        /// <summary> 
+        /// Expose server functionality
+        /// </summary>
+        public ArangoServerOperation Server
+        {
+            get
+            {
+                return new ArangoServerOperation(new ServerOperation(_connection));
+            }
+        }               
+                
+        /// <summary> 
+        /// Expose version functionality
+        /// </summary>
+        public ArangoVersionOperation Version
+        {
+            get
+            {
+                return new ArangoVersionOperation(new VersionOperation(_connection));
+            }
+        }        
+
         /// <summary>
         /// Creates Arango database object with specified alias connection.
         /// </summary>

--- a/src/Arango/Arango.Client/API/Collections/ArangoCollection.cs
+++ b/src/Arango/Arango.Client/API/Collections/ArangoCollection.cs
@@ -1,4 +1,4 @@
-﻿
+﻿using System.Collections.Generic;
 
 namespace Arango.Client
 {
@@ -36,6 +36,16 @@ namespace Arango.Client
         /// Maximum size setting for journals/datafiles.
         /// </summary>
         public int JournalSize { get; set; }
+
+        /// <summary>
+        /// Number of shards for the collection
+        /// </summary>        
+        public int? NumberOfShards { get; set; }
+
+        /// <summary>
+        /// Specifies the shard keys of a collection.
+        /// </summary>        
+        public List<string> ShardKeys { get; set; }
         
         /// <summary>
         /// Collection status.

--- a/src/Arango/Arango.Client/API/Collections/ArangoCollectionOperation.cs
+++ b/src/Arango/Arango.Client/API/Collections/ArangoCollectionOperation.cs
@@ -24,6 +24,15 @@ namespace Arango.Client
         }
         
         /// <summary>
+        /// Retrieves properties of collection with specified name.
+        /// </summary>
+        /// <param name="name">Collection name.</param>
+        public ArangoCollection Properties(string name)
+        {
+            return _collectionOperation.Properties(name);
+        }        
+        
+        /// <summary>
         /// Creates collection with specified configuration.
         /// </summary>
         /// <param name="collection">Collection object which contains configuration.</param>

--- a/src/Arango/Arango.Client/Arango.Client.csproj
+++ b/src/Arango/Arango.Client/Arango.Client.csproj
@@ -38,6 +38,10 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="API\Admin\ArangoServerOperation.cs" />
+    <Compile Include="API\Admin\ArangoServerRole.cs" />
+    <Compile Include="API\Admin\ArangoVersion.cs" />
+    <Compile Include="API\Admin\ArangoVersionOperation.cs" />
     <Compile Include="API\ArangoClient.cs" />
     <Compile Include="API\ArangoSettings.cs" />
     <Compile Include="API\Collections\ArangoCollection.cs" />
@@ -66,6 +70,8 @@
     <Compile Include="Protocol\Operations\DatabaseOperation.cs" />
     <Compile Include="Protocol\Operations\EdgeOperation.cs" />
     <Compile Include="Protocol\Operations\FunctionOperation.cs" />
+    <Compile Include="Protocol\Operations\ServerOperation.cs" />
+    <Compile Include="Protocol\Operations\VersionOperation.cs" />
     <Compile Include="Protocol\Request.cs" />
     <Compile Include="Protocol\RequestType.cs" />
     <Compile Include="Protocol\Response.cs" />
@@ -81,6 +87,7 @@
   <ItemGroup>
     <Folder Include="Protocol\" />
     <Folder Include="API\" />
+    <Folder Include="API\Admin\" />
     <Folder Include="API\Documents\" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Arango/Arango.Client/Protocol/Operations/DatabaseOperation.cs
+++ b/src/Arango/Arango.Client/Protocol/Operations/DatabaseOperation.cs
@@ -67,7 +67,10 @@ namespace Arango.Client.Protocol
 
             switch (response.StatusCode)
             {
+                // ArangoDB 1.4 returns 200 (Ok)
+                // whereas ArangoDB 2.0 returns 201 (Created)
                 case HttpStatusCode.OK:
+            	case HttpStatusCode.Created:
                     created = response.Document.Bool("result");
                     break;
                 default:

--- a/src/Arango/Arango.Client/Protocol/Operations/ServerOperation.cs
+++ b/src/Arango/Arango.Client/Protocol/Operations/ServerOperation.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using Arango.Client.Protocol;
+
+namespace Arango.Client.Protocol
+{
+    public class ServerOperation
+    {
+        private string _apiUri { get { return "_admin/server"; } }
+        private Connection _connection { get; set; }
+
+        internal ServerOperation(Connection connection)
+        {
+            _connection = connection;
+        }
+        
+        #region ROLE
+        
+        internal ArangoServerRole Role()
+        {
+            var request = new Request(RequestType.Server, HttpMethod.Get);
+            request.RelativeUri = _apiUri + "/role";           
+            
+            var response = _connection.Process(request);
+
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.OK:
+                    string roleString = response.Document.String("role"); 
+                    return new ArangoServerRole(roleString);
+                    
+                case HttpStatusCode.NotFound:
+                    // ArangoDB pre 2.0 does not have this handler
+                    return new ArangoServerRole(ArangoServerRole.RoleType.UNKNOWN);
+                    
+                default:
+                    if (response.IsException)
+                    {
+                        throw new ArangoException(
+                            response.StatusCode,
+                            response.Document.String("driverErrorMessage"),
+                            response.Document.String("driverExceptionMessage"),
+                            response.Document.Object<Exception>("driverInnerException")
+                        );
+                    }
+                    break;
+            }
+
+            return null;
+        }
+        
+        #endregion
+    }
+}

--- a/src/Arango/Arango.Client/Protocol/Operations/VersionOperation.cs
+++ b/src/Arango/Arango.Client/Protocol/Operations/VersionOperation.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using Arango.Client.Protocol;
+
+namespace Arango.Client.Protocol
+{
+    public class VersionOperation
+    {
+        private string _apiUri { get { return "_admin/version"; } }
+        private Connection _connection { get; set; }
+
+        internal VersionOperation(Connection connection)
+        {
+            _connection = connection;
+        }
+        
+        #region GET
+        
+        internal ArangoVersion Get()
+        {
+            var request = new Request(RequestType.Version, HttpMethod.Get);
+            request.RelativeUri = _apiUri;           
+            
+            var response = _connection.Process(request);
+
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.OK:
+                    string versionString = response.Document.String("version"); 
+                    return new ArangoVersion(versionString);
+                    
+                default:
+                    if (response.IsException)
+                    {
+                        throw new ArangoException(
+                            response.StatusCode,
+                            response.Document.String("driverErrorMessage"),
+                            response.Document.String("driverExceptionMessage"),
+                            response.Document.Object<Exception>("driverInnerException")
+                        );
+                    }
+                    break;
+            }
+
+            return null;
+        }
+        
+        #endregion
+    }
+}

--- a/src/Arango/Arango.Client/Protocol/RequestType.cs
+++ b/src/Arango/Arango.Client/Protocol/RequestType.cs
@@ -7,6 +7,8 @@ namespace Arango.Client.Protocol
         Document,
         Edge,
         Cursor,
-        Function
+        Function,
+        Version,
+        Server
     }
 }

--- a/src/Arango/Arango.Tests/Arango.Tests.csproj
+++ b/src/Arango/Arango.Tests/Arango.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="FunctionTests\ArangoFunctionTests.cs" />
     <Compile Include="QueryTests\AqlTests.cs" />
     <Compile Include="QueryTests\CursorTests.cs" />
+    <Compile Include="VersionTests\VersionTests.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Arango/Arango.Tests/ArangoCollectionTests/ArangoCollectionTests.cs
+++ b/src/Arango/Arango.Tests/ArangoCollectionTests/ArangoCollectionTests.cs
@@ -223,6 +223,44 @@ namespace Arango.Tests.ArangoCollectionTests
             Assert.AreEqual(5, returnedCollection.NumberOfShards);
         }        
         
+        
+        [Test()]
+        public void Should_create_collection_with_shard_keys()
+        {            
+            var db = Database.GetTestDatabase();
+            
+            if (! db.Server.Role().IsCluster())
+            {
+            	// do not execute this test in non-cluster mode
+            	return;
+            }
+
+            Database.DeleteTestCollection(Database.TestDocumentCollectionName);
+            	
+            // set collection data
+            var collection = new ArangoCollection();
+            collection.Name = Database.TestDocumentCollectionName;
+            collection.NumberOfShards = 2;
+            List<string> shardKeys = new List<string>();
+            shardKeys.Add("a");
+            shardKeys.Add("b");
+            collection.ShardKeys = shardKeys;
+            
+            // create collection in database
+            db.Collection.Create(collection);
+            
+            // get collection from database
+            ArangoCollection returnedCollection = db.Collection.Properties(Database.TestDocumentCollectionName);
+            
+            // get collection properties from database
+            Assert.AreEqual(collection.Id, returnedCollection.Id);
+            Assert.AreEqual(collection.Name, returnedCollection.Name);            
+            Assert.AreEqual(false, returnedCollection.IsVolatile);
+            Assert.AreEqual(false, returnedCollection.IsSystem);
+            Assert.AreEqual(2, returnedCollection.NumberOfShards);
+            Assert.AreEqual(shardKeys, returnedCollection.ShardKeys);
+        }                
+        
         public void Dispose()
         {
             Database.DeleteTestCollection(Database.TestDocumentCollectionName);

--- a/src/Arango/Arango.Tests/Database.cs
+++ b/src/Arango/Arango.Tests/Database.cs
@@ -26,7 +26,7 @@ namespace Arango.Tests
             TestDocumentCollectionName = "testDocumentCollection001xyzLatif";
             TestEdgeCollectionName = "testEdgeCollection001xyzLatif";
             
-            Hostname = "localhost";
+            Hostname = "127.0.0.1";
             Port = 8529;
             IsSecured = false;
             DatabaseName = TestDatabaseGeneral;
@@ -52,13 +52,13 @@ namespace Arango.Tests
         
         public static void CreateTestDatabase(string databaseName)
         {
-            DeleteTestDatabase(Database.TestDatabaseGeneral);
+            DeleteTestDatabase(databaseName);
             
             ArangoClient.CreateDatabase(
                 Database.Hostname,
                 Database.Port,
                 Database.IsSecured,
-                Database.TestDatabaseGeneral,
+                databaseName,
                 Database.UserName,
                 Database.Password
             );
@@ -74,13 +74,13 @@ namespace Arango.Tests
                 Database.Password
             );
             
-            if (databases.Contains(Database.TestDatabaseGeneral))
+            if (databases.Contains(databaseName))
             {
                 ArangoClient.DeleteDatabase(
                     Database.Hostname,
                     Database.Port,
                     Database.IsSecured,
-                    Database.TestDatabaseGeneral,
+                    databaseName,
                     Database.UserName,
                     Database.Password
                 );

--- a/src/Arango/Arango.Tests/VersionTests/VersionTests.cs
+++ b/src/Arango/Arango.Tests/VersionTests/VersionTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using NUnit.Framework;
+using Arango.Client;
+using System.Text.RegularExpressions;
+
+namespace Arango.Tests.VersionTests
+{
+    [TestFixture()]
+    public class ArangoVersionTests : IDisposable
+    {
+    	public ArangoVersionTests()
+    	{
+    	       Database.CreateTestDatabase(Database.TestDatabaseGeneral);
+    	}
+    	
+        [Test()]
+        public void Should_read_version()
+        {
+        	var db = Database.GetTestDatabase();
+        	ArangoVersion version = db.Version.Get();
+        	
+        	Assert.IsTrue(version.Major >= 1);
+        	Assert.IsTrue(version.Minor >= 0);
+        	Assert.IsTrue(version.PatchLevel >= 0);
+        	
+        	Assert.IsTrue(version.toInt() >= 13000);
+        	
+        	Regex re = new Regex(@"^\d+\.\d+\.\d+.*$");
+        	Assert.IsTrue(re.IsMatch(version.Version));
+        }
+        
+        public void Dispose()
+        {
+        	    Database.DeleteTestDatabase(Database.TestDatabaseGeneral);
+        }
+    }
+}

--- a/src/Arango/Arango.sln
+++ b/src/Arango/Arango.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
-# SharpDevelop 4.3
+# SharpDevelop 4.4
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arango.Client", "Arango.Client\Arango.Client.csproj", "{9B3F90DF-4E2C-4171-86B3-5C0FF4B3B07E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arango.Console", "Arango.Console\Arango.Console.csproj", "{D742C87C-7CBC-4333-B32C-7EAC619762CC}"


### PR DESCRIPTION
I have added support for specifying numberOfShards and shardKeys when creating a collection.
I have also implemented the Collection.Properties() method to retrieve collection properties from an existing collection.
Additionally I have implemented the call to /_admin/version to retrieve the server's version and role (if in a cluster, I needed this to activate/deactivate some tests).
