### PR TITLE
Update Connection.cs to support null Proxy

### DIFF
--- a/src/Arango/Arango.Client/Protocol/Connection.cs
+++ b/src/Arango/Arango.Client/Protocol/Connection.cs
@@ -67,6 +67,7 @@ namespace Arango.Client.Protocol
             }
 
             httpRequest.KeepAlive = true;
+            httpRequest.Proxy = null;
             httpRequest.SendChunked = false;
             httpRequest.Method = request.HttpMethod.ToString();
             httpRequest.UserAgent = ASettings.DriverName + "/" + ASettings.DriverVersion;


### PR DESCRIPTION
Updated Connection class to set Proxy to null for HttpWebRequest's. Users who need to go via a web proxy may need customize this code. Ideally we could create a property on Connection called Proxy of type WebProxy and default set it to null in the Connection constructor