### PR TITLE
New method: ToListFast<T> uses fastJSON to deserialize much quicker

### DIFF
--- a/src/Arango/Arango.Client/ExternalLibraries/dictator/DictionaryExtensions.cs
+++ b/src/Arango/Arango.Client/ExternalLibraries/dictator/DictionaryExtensions.cs
@@ -515,20 +515,7 @@ namespace Arango.Client
         /// </summary>
         public static bool Has(this Dictionary<string, object> dictionary, string fieldPath)
         {
-            var isValid = false;
-            
-            try
-            {
-                var fieldValue = GetFieldValue(dictionary, fieldPath);
-
-                isValid = true;
-            }
-            catch (Exception)
-            {
-                isValid = false;
-            }
-            
-            return isValid;
+            return HasFieldValue(dictionary, fieldPath);           
         }
         /// <summary>
         /// Checks if specified field has null value.
@@ -1397,6 +1384,65 @@ namespace Arango.Client
             
             return fieldValue;
         }
+
+        static bool HasFieldValue(Dictionary<string, object> dictionary, string fieldPath)
+        {
+            object fieldValue = null;
+            var fieldNames = new[] { fieldPath };
+            var parentDictionary = dictionary;
+
+            // split field path to separate field name elements if necessary
+            if (fieldPath.Contains("."))
+            {
+                fieldNames = fieldPath.Split('.');
+            }
+
+            for (int i = 0; i < fieldNames.Length; i++)
+            {
+                var fieldName = fieldNames[i];
+                var arrayContent = "";
+
+                if (fieldName.Contains("[") && fieldName.Contains("]"))
+                {
+                    var firstIndex = fieldName.IndexOf('[');
+                    var lastIndex = fieldName.IndexOf(']');
+
+                    arrayContent = fieldName.Substring(firstIndex + 1, lastIndex - firstIndex - 1);
+                    fieldName = fieldName.Substring(0, firstIndex);
+                }
+
+                // throw exception if the field is not present in dictionary
+                if (!parentDictionary.ContainsKey(fieldName))
+                {
+                    return false;
+                }
+
+                // current field name is final - retrieve field value and break loop
+                if (i == (fieldNames.Length - 1))
+                {
+                    fieldValue = GetFieldObject(fieldName, arrayContent, parentDictionary);
+
+                    break;
+                }
+
+                var tempParentObject = GetFieldObject(fieldName, arrayContent, parentDictionary);
+
+                // descendant field is dictionary - set is as current parent dictionary
+                if (tempParentObject is Dictionary<string, object>)
+                {
+                    parentDictionary = (Dictionary<string, object>)tempParentObject;
+                }
+                // can not continue with processing - throw exception
+                else
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+
         /// <summary>
         /// Retrieves object from specified field depending on array content.
         /// </summary>


### PR DESCRIPTION
Hi. I noticed that the current AQuery.ToList&lt;T&gt; is very slow. So I made this new method instead, which use the fastJSON already used in the project. When profiling with Visual Studio, for my example collection (400 lines pretty print JSON) it was up to 40x quicker.

The best solution would of course be to rewrite the AQuery.ToList&lt;T&gt; instead of creating a new method, but I leave that up to you, because I haven't had the time to really grok you code, so maybe my ToListFast has a hug bug I don't know about...