### PR TITLE
Added support for Nullable types.

### DIFF
--- a/src/Arango/Arango.Client/ExternalLibraries/dictator/DictionaryExtensions.cs
+++ b/src/Arango/Arango.Client/ExternalLibraries/dictator/DictionaryExtensions.cs
@@ -1689,6 +1689,20 @@ namespace Arango.Client
                             propertyInfo.SetValue(stronglyTypedObject, fieldValue, null);
                         }
                     }
+                    else if (propertyInfo.PropertyType.IsGenericType 
+                        && propertyInfo.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    {
+                        var propertyType = propertyInfo.PropertyType.GetGenericArguments()[0];
+
+                        if ((fieldValue == null) || (propertyType == fieldType))
+                        {
+                            propertyInfo.SetValue(stronglyTypedObject, fieldValue, null);
+                        }
+                        else
+                        {
+                            propertyInfo.SetValue(stronglyTypedObject, Convert.ChangeType(fieldValue, propertyType), null);
+                        }
+                    }
                     // property is basic type
                     else
                     {


### PR DESCRIPTION
I got an error when fetching a DateTime? from the database.

            var result = query.ToDocuments();

            var myList = new List<MyType>();
            foreach (var doc in result.Value)
            {
                var dict = doc.Object("vertex").ToObjectDictionary();
                var xxx = dict.ToObject<MyType>();

on the last line there.

I see in the code that this is from a dependency, so I don't know if you want it, but it does solve a problem.

Since I'm not on 3.0 yet, I fixed it on the 2.x branch only.