### PR TITLE
Allow the use of Web Proxy, keeping the default behaviour the same

### DIFF
--- a/src/Arango/Arango.Client/Protocol/Connection.cs
+++ b/src/Arango/Arango.Client/Protocol/Connection.cs
@@ -28,30 +28,29 @@ namespace Arango.Client.Protocol
 
         internal Uri BaseUri { get; set; }
 
+        internal bool UseWebProxy { get; set; }
+
         #endregion
         
-        internal Connection(string alias, string hostname, int port, bool isSecured, string username, string password)
+        internal Connection(string alias, string hostname, int port, bool isSecured, string userName, string password, bool useWebProxy = false)
         {
             Alias = alias;
             Hostname = hostname;
             Port = port;
             IsSecured = isSecured;
-            Username = username;
+            Username = userName;
             Password = password;
+
+            UseWebProxy = useWebProxy;
 
             BaseUri = new Uri((isSecured ? "https" : "http") + "://" + hostname + ":" + port + "/");
         }
 
-        internal Connection(string alias, string hostname, int port, bool isSecured, string databaseName, string userName, string password)
+        internal Connection(string alias, string hostname, int port, bool isSecured, string databaseName, string userName, string password, bool useWebProxy = false)
+            : this(alias, hostname, port, isSecured, userName, password, useWebProxy)
         {
-            Alias = alias;
-            Hostname = hostname;
-            Port = port;
-            IsSecured = isSecured;
             DatabaseName = databaseName;
-            Username = userName;
-            Password = password;
-
+            
             BaseUri = new Uri((isSecured ? "https" : "http") + "://" + hostname + ":" + port + "/_db/" + databaseName + "/");
         }
 
@@ -65,7 +64,10 @@ namespace Arango.Client.Protocol
             }
 
             httpRequest.KeepAlive = true;
-            httpRequest.Proxy = null;
+            if (!UseWebProxy)
+            {
+                httpRequest.Proxy = null;
+            }
             httpRequest.SendChunked = false;
             httpRequest.Method = request.HttpMethod.ToString();
             httpRequest.UserAgent = ASettings.DriverName + "/" + ASettings.DriverVersion;

--- a/src/Arango/Arango.Client/Public/ASettings.cs
+++ b/src/Arango/Arango.Client/Public/ASettings.cs
@@ -33,26 +33,26 @@ namespace Arango.Client
         
         #region AddConnection
         
-        public static void AddConnection(string alias, string hostname, int port, bool isSecured)
+        public static void AddConnection(string alias, string hostname, int port, bool isSecured, bool useWebProxy = false)
         {
-            AddConnection(alias, hostname, port, isSecured, "", "");
+            AddConnection(alias, hostname, port, isSecured, "", "", useWebProxy);
         }
 
-        public static void AddConnection(string alias, string hostname, int port, bool isSecured, string username, string password)
+        public static void AddConnection(string alias, string hostname, int port, bool isSecured, string username, string password, bool useWebProxy = false)
         {
-            var connection = new Connection(alias, hostname, port, isSecured, username, password);
+            var connection = new Connection(alias, hostname, port, isSecured, username, password, useWebProxy);
 
             _connections.Add(alias, connection);
         }
         
-        public static void AddConnection(string alias, string hostname, int port, bool isSecured, string databaseName)
+        public static void AddConnection(string alias, string hostname, int port, bool isSecured, string databaseName, bool useWebProxy = false)
         {
-            AddConnection(alias, hostname, port, isSecured, databaseName, "", "");
+            AddConnection(alias, hostname, port, isSecured, databaseName, "", "", useWebProxy);
         }
         
-        public static void AddConnection(string alias, string hostname, int port, bool isSecured, string databaseName, string username, string password)
+        public static void AddConnection(string alias, string hostname, int port, bool isSecured, string databaseName, string username, string password, bool useWebProxy = false)
         {
-            var connection = new Connection(alias, hostname, port, isSecured, databaseName, username, password);
+            var connection = new Connection(alias, hostname, port, isSecured, databaseName, username, password, useWebProxy);
 
             _connections.Add(alias, connection);
         }


### PR DESCRIPTION
Added the possibiliy to enable the use of web proxy. In my case making debugging request a lot easier.

Made the property optional and the default the same as the original code to prevent breaking current implementations.