### PR TITLE
Fixed "type" sent as string instead of integer when creating collections

### DIFF
--- a/src/Arango/Arango.Client/Public/ACollection.cs
+++ b/src/Arango/Arango.Client/Public/ACollection.cs
@@ -22,7 +22,7 @@ namespace Arango.Client
         public ACollection Type(ACollectionType value)
         {
             // set enum format explicitely to override global setting
-            _parameters.Enum(ParameterName.Type, value, EnumFormat.Object);
+            _parameters.Enum(ParameterName.Type, value, EnumFormat.Integer);
         	
         	return this;
         }


### PR DESCRIPTION
"Type" was being sent as a string ("Document"/"Edge") instead of integers ("2"/"3") when a collection is created. This caused collections to always be created as document collections.
I picked this up because the "Should_create_edge_collection" unit test and a number of EdgeOperationTests were failing.